### PR TITLE
[IMP]pms_api_rest: by_default and pricelist_ids in board service GET

### DIFF
--- a/pms_api_rest/datamodels/pms_board_service.py
+++ b/pms_api_rest/datamodels/pms_board_service.py
@@ -19,3 +19,5 @@ class PmsBoardServiceInfo(Datamodel):
     boardServiceId = fields.Integer(required=False, allow_none=False)
     productIds = fields.List(fields.Integer(required=False, allow_none=False))
     boardServiceLineIds = fields.List(fields.Integer(required=False, allow_none=False))
+    isDefaultBoardService = fields.Boolean(required=False, allow_none=False)
+    pricelistIds = fields.List(fields.Integer(required=False, allow_none=False))

--- a/pms_api_rest/services/pms_board_service_service.py
+++ b/pms_api_rest/services/pms_board_service_service.py
@@ -39,7 +39,9 @@ class PmsBoardServiceService(Component):
         if board_services_search_param.pmsPropertyId:
             domain.extend(
                 [
+                    "|",
                     ("pms_property_id", "=", board_services_search_param.pmsPropertyId),
+                    ("pms_property_id", "=", False),
                 ]
             )
 
@@ -56,6 +58,8 @@ class PmsBoardServiceService(Component):
                     amount=round(board_service.amount, 2),
                     boardServiceId=board_service.pms_board_service_id,
                     boardServiceLineIds=board_service.board_service_line_ids.ids,
+                    isDefaultBoardService=board_service.by_default,
+                    pricelistIds=board_service.pricelist_ids,
                 )
             )
         if external_app:
@@ -107,6 +111,8 @@ class PmsBoardServiceService(Component):
                 roomTypeId=board_service.pms_room_type_id.id,
                 amount=round(board_service.amount),
                 boardServiceLineIds=board_service.board_service_line_ids.ids,
+                isDefaultBoardService=board_service.by_default,
+                pricelistIds=board_service.pricelist_ids,
             )
         else:
             raise MissingError(_("Board Service not found"))


### PR DESCRIPTION
This pull request includes several updates to the `pms_api_rest` module, specifically focusing on the `PmsBoardServiceInfo` datamodel and the `get_board_services` and `get_board_service` methods in the `pms_board_service_service.py` file. The most significant changes are the addition of new fields and search parameters to enhance functionality.

### Enhancements to Datamodel and Methods:

* [`pms_api_rest/datamodels/pms_board_service.py`](diffhunk://#diff-c27c3427603de5b54361e6d238ce10a0374c2d8e7101fb48de4f2b9c58af85aeR22-R23): Added `isDefaultBoardService` and `pricelistIds` fields to the `PmsBoardServiceInfo` datamodel.

* [`pms_api_rest/services/pms_board_service_service.py`](diffhunk://#diff-d620286f5fdb647479326167760eca5a1c4583cb2abe4529ea6170fe708495ffR61-R62): Updated the `get_board_services` method to include `isDefaultBoardService` and `pricelistIds` in the returned data.

* [`pms_api_rest/services/pms_board_service_service.py`](diffhunk://#diff-d620286f5fdb647479326167760eca5a1c4583cb2abe4529ea6170fe708495ffR114-R115): Updated the `get_board_service` method to include `isDefaultBoardService` and `pricelistIds` in the returned data.

### Improvements to Search Parameters:

* [`pms_api_rest/services/pms_board_service_service.py`](diffhunk://#diff-d620286f5fdb647479326167760eca5a1c4583cb2abe4529ea6170fe708495ffR42-R44): Enhanced the search parameters in the `get_board_services` method to account for cases where `pms_property_id` can be either a specific value or `False`.