### PR TITLE
[RFC]pms_api_rest: refact multiproperty features

### DIFF
--- a/pms_api_rest/models/ota_property_settings.py
+++ b/pms_api_rest/models/ota_property_settings.py
@@ -8,7 +8,6 @@ class OtaPropertySettings(models.Model):
         string="PMS Property",
         help="PMS Property",
         comodel_name="pms.property",
-        default=lambda self: self.env.user.get_active_property_ids()[0],
     )
     agency_id = fields.Many2one(
         string="Partner",

--- a/pms_api_rest/models/pms_api_log.py
+++ b/pms_api_rest/models/pms_api_log.py
@@ -10,7 +10,6 @@ class PmsApiLog(models.Model):
         string="PMS Property",
         help="PMS Property",
         comodel_name="pms.property",
-        default=lambda self: self.env.user.get_active_property_ids()[0],
     )
     client_id = fields.Many2one(
         string="Client",


### PR DESCRIPTION
This pull request includes changes to the `pms_api_rest` models to remove the default value assignment for certain fields. 
This is related with de pms base refact multiproperties: https://github.com/OCA/pms/pull/320 
The most important changes are:

Fields modification:

* [`pms_api_rest/models/ota_property_settings.py`](diffhunk://#diff-a9890cf80d631cb6db00494206b92e01447ff8de1bcf1ba2ccd0d7c4d18817a5L11): Removed the default value assignment for the `property_id` field in the `OtaPropertySettings` model.
* [`pms_api_rest/models/pms_api_log.py`](diffhunk://#diff-c5dcbfce1deaa996102a4d3606ebaa98a87e39d4ef9bb0477a90392c1bd1725aL13): Removed the default value assignment for the `property_id` field in the `PmsApiLog` model.