### PR TITLE
[IMP] pms_api_rest: adds saleChannelId field to agency datamodel

### DIFF
--- a/pms_api_rest/datamodels/pms_agency.py
+++ b/pms_api_rest/datamodels/pms_agency.py
@@ -14,3 +14,4 @@ class PmsAgencyInfo(Datamodel):
     id = fields.Integer(required=True, allow_none=False)
     name = fields.String(required=True, allow_none=False)
     imageUrl = fields.String(required=False, allow_none=True)
+    saleChannelId = fields.Integer(required=False, allow_none=True)

--- a/pms_api_rest/services/pms_agency_service.py
+++ b/pms_api_rest/services/pms_agency_service.py
@@ -45,6 +45,7 @@ class PmsAgencyService(Component):
                     imageUrl=url_image_pms_api_rest(
                         "res.partner", agency.id, "image_128"
                     ),
+                    saleChannelId=agency.sale_channel_id.id
                 )
             )
         return result_agencies
@@ -79,6 +80,7 @@ class PmsAgencyService(Component):
                 id=agency.id,
                 name=agency.name if agency.name else None,
                 imageUrl=url_image_pms_api_rest("res.partner", agency.id, "image_128"),
+                saleChannelId=agency.sale_channel_id.id
             )
         else:
             raise MissingError(_("Agency not found"))


### PR DESCRIPTION
This pull request includes changes to the `pms_api_rest` module to add a new field, `saleChannelId`, to the `PmsAgencyInfo` data model and update relevant service methods to include this field.

Changes to data model:

* [`pms_api_rest/datamodels/pms_agency.py`](diffhunk://#diff-37e51529e9ea051e27e0dbd9e75f5716e665777bc77e4cc7ec52c73ff4f16ce5R17): Added the `saleChannelId` field to the `PmsAgencyInfo` datamodel.

Updates to service methods:

* [`pms_api_rest/services/pms_agency_service.py`](diffhunk://#diff-9ee8c9ad5a3f57959b543d0c0b1ea430466ce19ae8a1cd5755233f09d1481ed6R48): Updated the `get_agencies` and `get_agency` methods to include the `saleChannelId` when constructing agency information.