### PR TITLE
[IMP] 14.0-pms_api_rest: get folio payment link service

### DIFF
--- a/pms_api_rest/datamodels/pms_folio.py
+++ b/pms_api_rest/datamodels/pms_folio.py
@@ -115,3 +115,13 @@ class PmsFolioPublicInfo(Datamodel):
         NestedModel("pms.reservation.public.info"), required=True, allow_none=False
     )
     cardexWarning = fields.String(required=False, allow_none=True)
+
+
+class PmsFolioPaymentLinkInfo(Datamodel):
+    _name = "pms.folio.payment.link.info"
+    paymentLink = fields.String(required=True, allow_none=False)
+
+
+class PmsFolioPaymentLinkSearchParam(Datamodel):
+    _name = "pms.folio.payment.link.search.param"
+    amount = fields.Float(required=False, allow_none=True)

--- a/pms_api_rest/services/pms_folio_service.py
+++ b/pms_api_rest/services/pms_folio_service.py
@@ -2553,7 +2553,10 @@ class PmsFolioService(Component):
         except AccessError:
             raise MissingError(_("Folio not found"))
 
-    def _generate_payment_link(self, folio_record):
+    def _generate_payment_link(self, folio_record, amount=False):
+        vals = dict()
+        if amount:
+            vals["amount"] = amount
         wizard_payment_link = (
             self.env["payment.link.wizard"]
             .with_context(
@@ -2561,7 +2564,7 @@ class PmsFolioService(Component):
                 active_model="pms.folio",
             )
             .sudo()
-            .create({})
+            .create(vals)
         )
         wizard_payment_link._generate_link()
         return wizard_payment_link.link
@@ -2695,4 +2698,28 @@ class PmsFolioService(Component):
                 folio_record
             ),
             reservations=reservations,
+        )
+
+    @restapi.method(
+        [
+            (
+                [
+                    "/<int:folio_id>/payment-link",
+                ],
+                "GET",
+            )
+        ],
+        input_param=Datamodel("pms.folio.payment.link.search.param", is_list=False),
+        output_param=Datamodel("pms.folio.payment.link.info", is_list=False),
+        auth="jwt_api_pms",
+    )
+    def get_folio_payment_link(self, folio_id, folio_payment_link_search_param):
+        folio = self.env["pms.folio"].sudo().browse(folio_id)
+        if not folio.exists():
+            raise MissingError(_("Folio not found"))
+        pms_api_check_access(user=self.env.user, records=folio)
+        payment_link = self._generate_payment_link(folio, folio_payment_link_search_param.amount)
+        PmsFolioPaymentLinkInfo = self.env.datamodels["pms.folio.payment.link.info"]
+        return PmsFolioPaymentLinkInfo(
+            paymentLink=payment_link,
         )


### PR DESCRIPTION
This pull request introduces new functionality for handling payment links within the `pms_api_rest` module. The changes include the addition of new data models, modifications to existing service methods, and the introduction of a new API endpoint for retrieving payment links.

Key changes include:

### New Data Models:
* Added `PmsFolioPaymentLinkInfo` and `PmsFolioPaymentLinkSearchParam` classes to handle payment link information and search parameters respectively in `pms_api_rest/datamodels/pms_folio.py`.

### Service Method Updates:
* Modified `_generate_payment_link` method to accept an optional `amount` parameter and include it in the payment link creation process if provided in `pms_api_rest/services/pms_folio_service.py`.

### New API Endpoint:
* Added `get_folio_payment_link` method to provide an API endpoint for retrieving payment links based on folio ID and optional search parameters in `pms_api_rest/services/pms_folio_service.py`.