### PR TITLE
[IMP] pms_api_rest: line notes to invoices in post and section_id field in get

### DIFF
--- a/pms_api_rest/datamodels/pms_folio_sale_line.py
+++ b/pms_api_rest/datamodels/pms_folio_sale_line.py
@@ -18,3 +18,4 @@ class PmsFolioSaleInfo(Datamodel):
     displayType = fields.String(required=False, allow_none=True)
     defaultInvoiceTo = fields.Integer(required=False, allow_none=True)
     isDownPayment = fields.Boolean(required=False, allow_none=True)
+    sectionId = fields.Integer(required=False, allow_none=True)

--- a/pms_api_rest/services/pms_folio_service.py
+++ b/pms_api_rest/services/pms_folio_service.py
@@ -1397,6 +1397,7 @@ class PmsFolioService(Component):
                             if sale_line.default_invoice_to
                             else None,
                             isDownPayment=sale_line.is_downpayment,
+                            sectionId= sale_line.section_id.id
                         )
                     )
 
@@ -1528,6 +1529,12 @@ class PmsFolioService(Component):
             if line.section_id and line.section_id.id not in sale_lines_to_invoice.ids:
                 sale_lines_to_invoice |= line.section_id
                 lines_to_invoice_dict[line.section_id.id] = 0
+        line_notes = self.env["folio.sale.line"].sudo().search([
+            ("display_type", "=", "line_note"),
+        ]).filtered(lambda l: l.section_id in sale_lines_to_invoice)
+        for line_note in line_notes:
+            if line_note.id not in lines_to_invoice_dict:
+                lines_to_invoice_dict[line_note.id] = 0
         folios_to_invoice = sale_lines_to_invoice.folio_id
         invoices = folios_to_invoice._create_invoices(
             lines_to_invoice=lines_to_invoice_dict,

--- a/pms_api_rest/services/pms_invoice_service.py
+++ b/pms_api_rest/services/pms_invoice_service.py
@@ -637,7 +637,6 @@ class PmsInvoiceService(Component):
                 )
                 .mapped("section_id.id")
             )
-            pms_api_check_access(user=self.env.user, records=new_section_ids)
             if new_section_ids:
                 lines_to_invoice.update(
                     {section_id: 0 for section_id in new_section_ids}
@@ -650,7 +649,7 @@ class PmsInvoiceService(Component):
                 )
             ][0]
             # Update name of new invoice lines
-            for item in filter(lambda l: not l[2]["display_type"], new_invoice_lines):
+            for item in filter(lambda l: not l[2].get("display_type"), new_invoice_lines):
                 item[2]["name"] = [
                     line.name
                     for line in newInvoiceLinesInfo


### PR DESCRIPTION
This pull request introduces changes to support the handling of `sectionId` in folio sale lines within the PMS API. The updates include adding a new field to the datamodel, modifying service methods to incorporate `sectionId`, and implementing logic to process line notes based on their section association.

### Changes to support `sectionId` in folio sale lines:

#### Datamodel updates:
* Added a new field `sectionId` to the `PmsFolioSaleInfo` datamodel to store section information for folio sale lines. (`pms_api_rest/datamodels/pms_folio_sale_line.py`, [pms_api_rest/datamodels/pms_folio_sale_line.pyR21](diffhunk://#diff-abb647df3e33d4056e083723d4fd87ec0e541905f72e2f050f5026d50c56aac3R21))

#### Service method updates:
* Updated the `get_folio_sale_lines` method to include `sectionId` when constructing folio sale line objects. (`pms_api_rest/services/pms_folio_service.py`, [pms_api_rest/services/pms_folio_service.pyR1400](diffhunk://#diff-b2b7660ac329e3fa91f71cca8f7cd4b2e42ac59d052973eb3e32bfcba4e7e816R1400))
* Enhanced the `create_folio_invoices` method to process line notes associated with sections. This includes filtering folio sale lines with `display_type` set to "line_note" and ensuring their IDs are added to the `lines_to_invoice_dict`. (`pms_api_rest/services/pms_folio_service.py`, [pms_api_rest/services/pms_folio_service.pyR1532-R1537](diffhunk://#diff-b2b7660ac329e3fa91f71cca8f7cd4b2e42ac59d052973eb3e32bfcba4e7e816R1532-R1537))