### PR TITLE
[FIX] 16.0-pms_api_rest: action cancel and confirm to folio & cancelledReason field to reservation

### DIFF
--- a/pms_api_rest/datamodels/pms_reservation.py
+++ b/pms_api_rest/datamodels/pms_reservation.py
@@ -78,6 +78,7 @@ class PmsReservationInfo(Datamodel):
     externalReference = fields.String(required=False, allow_none=True)
     stateCode = fields.String(required=False, allow_none=True)
     stateDescription = fields.String(required=False, allow_none=True)
+    cancelledReason = fields.String(required=False, allow_none=True)
     children = fields.Integer(required=False, allow_none=True)
     readyForCheckin = fields.Boolean(required=False, allow_none=True)
     checkinPartnerCount = fields.Integer(required=False, allow_none=True)

--- a/pms_api_rest/services/pms_folio_service.py
+++ b/pms_api_rest/services/pms_folio_service.py
@@ -1121,6 +1121,11 @@ class PmsFolioService(Component):
         if not folio_record:
             raise MissingError(_("Folio not found"))
         pms_api_check_access(user=self.env.user, records=folio_record)
+        if pms_folio_info.cancelReservations:
+            folio_record.action_cancel()
+        elif pms_folio_info.confirmReservations:
+            for reservation in folio_record.reservation_ids:
+                reservation.action_confirm()
         pms_folio_info = self.adjust_board_services_input(pms_folio_info)
         folio_vals = self.env["pms.folio"].create_folio_vals(
             folio_record=folio_record, pms_folio_info=pms_folio_info

--- a/pms_api_rest/services/pms_reservation_service.py
+++ b/pms_api_rest/services/pms_reservation_service.py
@@ -184,6 +184,9 @@ class PmsReservationService(Component):
                     line.is_reselling for line in reservation.reservation_line_ids
                 ),
                 isBlocked=reservation.blocked,
+                cancelledReason=reservation.cancelled_reason
+                if reservation.cancelled_reason
+                else None
             )
         return res
 


### PR DESCRIPTION
This pull request introduces enhancements to the PMS Reservation API by adding support for handling cancellation reasons and updating reservation states. The key changes include extending the data model, updating the folio service to handle reservation confirmations and cancellations, and enhancing the reservation retrieval logic to include cancellation reasons.

### Enhancements to PMS Reservation API:

* **Data Model Update**:
  - Added a new field `cancelledReason` to the `PmsReservationInfo` data model to store the reason for reservation cancellations. 

* **Reservation Retrieval Improvements**:
  - Modified the `get_reservation` method to include the `cancelledReason` field in the response, ensuring that cancellation reasons are surfaced when available. (`pms_api_rest/services/pms_reservation_service.py`, 
 
* **Folio Service Enhancements**:
  - Updated the `update_folio` method to handle reservation cancellations (`action_cancel`) and confirmations (`action_confirm`) based on the `pms_folio_info` input.