### PR TITLE
[16.0] [FIX] pms-api-rest: add new endpoint to create reservations belonging…

### DIFF
--- a/pms_api_rest/datamodels/pms_reservation.py
+++ b/pms_api_rest/datamodels/pms_reservation.py
@@ -104,7 +104,9 @@ class PmsReservationInfo(Datamodel):
     nights = fields.Integer(required=False, allow_none=True)
     numServices = fields.Integer(required=False, allow_none=True)
 
-    reservationLines = fields.List(NestedModel("pms.reservation.line.info"))
+    reservationLines = fields.List(
+        NestedModel("pms.reservation.line.info"), required=False, allow_none=True
+    )
     services = fields.List(
         NestedModel("pms.service.info"), required=False, allow_none=True
     )

--- a/pms_api_rest/services/pms_folio_service.py
+++ b/pms_api_rest/services/pms_folio_service.py
@@ -700,6 +700,49 @@ class PmsFolioService(Component):
         [
             (
                 [
+                    "/<int:folio_id>/reservations",
+                ],
+                "POST",
+            )
+        ],
+        input_param=Datamodel("pms.folio.info", is_list=False),
+        auth="jwt_api_pms",
+    )
+    def create_folio_reservations(self, folio_id, folio_info):
+        folio_record = self.env["pms.folio"].sudo().search([("id", "=", folio_id)])
+        if not folio_record:
+            raise MissingError(_("Folio not found"))
+        pms_api_check_access(user=self.env.user, records=folio_record)
+        for reservation in folio_info.reservations:
+            new_reservation_record = self.env["pms.reservation"].create(
+                {
+                    "folio_id": folio_record.id,
+                    "pricelist_id": folio_info.pricelistId,
+                    "pms_property_id": folio_record.pms_property_id.id,
+                    "checkin": datetime.strptime(
+                        reservation.checkin, "%Y-%m-%d"
+                    ).date(),
+                    "checkout": datetime.strptime(
+                        reservation.checkout, "%Y-%m-%d"
+                    ).date(),
+                    "room_type_id": reservation.roomTypeId,
+                    "adults": reservation.adults,
+                    "children": reservation.children or 0,
+                    "board_service_room_id": reservation.boardServiceId,
+                    "preferred_room_id": reservation.preferredRoomId
+                    if reservation.preferredRoomId
+                    else None,
+                    "splitted": reservation.isSplitted
+                    if reservation.isSplitted
+                    else False,
+                    "reservation_type": reservation.reservationType or "normal",
+                }
+            )
+
+    @restapi.method(
+        [
+            (
+                [
                     "/",
                 ],
                 "POST",


### PR DESCRIPTION
This pull request introduces two main changes: an update to the `PmsReservationInfo` datamodel to make the `reservationLines` field optional and nullable, and the addition of a new method to create folio reservations via a REST API endpoint. These changes enhance flexibility in handling reservation data and expand the API's functionality.

### Updates to `PmsReservationInfo` datamodel:
* Modified the `reservationLines` field in the `PmsReservationInfo` datamodel to make it optional (`required=False`) and nullable (`allow_none=True`), aligning it with other fields like `services` for consistency. (`pms_api_rest/datamodels/pms_reservation.py`, [pms_api_rest/datamodels/pms_reservation.pyL107-R109](diffhunk://#diff-a75949cdb8342a1ad3b6a3561adb85f5d4602d3a3796825640d64a16fa3093a6L107-R109))

### New API functionality:
* Added the `create_folio_reservations` method in `PmsFolioService` to allow creating reservations for a folio via a new POST endpoint (`/p/<int:folio_id>/reservations`). This method validates the folio, checks user access, and creates reservation records using the provided data. (`pms_api_rest/services/pms_folio_service.py`, [pms_api_rest/services/pms_folio_service.pyR699-R744](diffhunk://#diff-b2b7660ac329e3fa91f71cca8f7cd4b2e42ac59d052973eb3e32bfcba4e7e816R699-R744))… to existent folio